### PR TITLE
Fix CMake installation and add focused member to output_s

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.19)
-project(swayipc-cpp)
+project(
+  swayipc-cpp
+  VERSION 1.0.0
+)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,36 @@
+pkgname=swayipc-cpp
+_name="${pkgname%-git}"
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='A simple C++17 library for controlling sway window manager.'
+url='https://github.com/aokellermann/swayipc-cpp'
+arch=(x86_64)
+makedepends=(cmake extra-cmake-modules git conan1)
+provides=("$_name")
+conflicts=("$_name")
+source=("git+$url")
+sha256sums=(SKIP)
+
+_cmake_flags=(
+	-DCMAKE_BUILD_TYPE=Release
+	-DCMAKE_INSTALL_LIBDIR=lib
+	-DCMAKE_INSTALL_PREFIX=/usr
+)
+
+build() {
+	mkdir build
+	cd build
+	cmake ../$pkgname "${_cmake_flags[@]}" -DBUILD_SHARED_LIBS=ON
+	make
+}
+
+check() {
+	cd build
+	cmake ../$pkgname "${_cmake_flags[@]}" -DBUILD_SHARED_LIBS=ON
+	make
+}
+
+package() {
+	cd build
+	make "DESTDIR=$pkgdir" install
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A simple C++17 library for controlling sway window manager.
 
+# Installing
+
+A `PKGBUILD` is attached in this repository:
+
+```sh
+mkdir build && cd build
+curl -o PKGBUILD https://raw.githubusercontent.com/aokellermann/swayipc-cpp/master/PKGBUILD
+yay -Bi .
+```
+
 # Examples
 
 ## Connecting

--- a/cmake/swayipc_cppConfig.cmake.in
+++ b/cmake/swayipc_cppConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+find_package(Threads REQUIRED)
+find_package(nlohmann_json REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/swayipc_cpp_targets.cmake")
+
+check_required_components(swayipc_cpp)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,6 +13,6 @@ foreach(file ${source_files})
     target_link_libraries(
         ${example}
         PRIVATE
-        swayipc_cpp_static
+        swayipc_cpp
     )
 endforeach()

--- a/swayipc-cpp/include/swayipc-cpp/container.hpp
+++ b/swayipc-cpp/include/swayipc-cpp/container.hpp
@@ -112,6 +112,7 @@ struct container {
     std::optional<idle_inhibitors_s> idle_inhibitors;
     std::optional<int> window;
     std::optional<window_properties_s> window_properties;
+    std::optional<std::string> current_workspace;
 
     container* find(std::function<bool(const container&)>);
     std::vector<container*> find_many(std::function<bool(const container&)>);

--- a/swayipc-cpp/include/swayipc-cpp/data.hpp
+++ b/swayipc-cpp/include/swayipc-cpp/data.hpp
@@ -63,6 +63,7 @@ struct output_s {
     std::optional<std::vector<mode_s>> modes;
     std::optional<mode_s> current_mode;
     std::optional<rect_s> rect;
+    std::optional<bool> focused;
 };
 JSON_TYPE_HEADER(output_s)
 

--- a/swayipc-cpp/src/CMakeLists.txt
+++ b/swayipc-cpp/src/CMakeLists.txt
@@ -1,9 +1,9 @@
 file(GLOB source_files *.cpp)
 
-add_library(swayipc_cpp_static STATIC ${source_files})
+add_library(swayipc_cpp ${source_files})
 
 target_link_libraries(
-    swayipc_cpp_static
+    swayipc_cpp
     PUBLIC
     nlohmann_json::nlohmann_json
     PRIVATE
@@ -11,7 +11,7 @@ target_link_libraries(
 )
 
 target_include_directories(
-    swayipc_cpp_static
+    swayipc_cpp
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/swayipc-cpp/include>
 )
@@ -19,10 +19,10 @@ target_include_directories(
 set(CMAKE_INSTALL_INCLUDEDIR include)
 set(CMAKE_INSTALL_BINDIR bin)
 set(CMAKE_INSTALL_LIBDIR lib)
-set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake)
+set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/swayipc_cpp)
 
 install(
-    TARGETS swayipc_cpp_static
+    TARGETS swayipc_cpp
     EXPORT swayipc_cpp_targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -41,29 +41,23 @@ install(
     DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
 )
 
-file(
-    WRITE
-    ${CMAKE_BINARY_DIR}/Config.cmake.in
-    "@PACKAGE_INIT@\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/swayipc_cpp_targets.cmake\")"
-)
-
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    ${CMAKE_BINARY_DIR}/Config.cmake.in
-    swayipc_cpp-config.cmake
+    ${CMAKE_SOURCE_DIR}/cmake/swayipc_cppConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cppConfig.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
     PATH_VARS CMAKE_INSTALL_LIBDIR
 )
 
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cpp_version.cmake
-    VERSION 1.0.0
+    ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cppConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
 )
 
 ### Install Config and ConfigVersion files
 install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cpp-config.cmake
-          ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cpp_version.cmake
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cppConfig.cmake
+          ${CMAKE_CURRENT_BINARY_DIR}/swayipc_cppConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
 )

--- a/swayipc-cpp/src/container.cpp
+++ b/swayipc-cpp/src/container.cpp
@@ -98,6 +98,7 @@ DEFINE_TYPE_DEFAULT(container, id, name, type, border, current_border_width,
                     deco_rect, geometry, urgent, sticky, marks,
                     focused, focus, nodes, floating_nodes, representation,
                     fullscreen_mode, app_id, pid, visible, shell,
-                    inhibit_idle, idle_inhibitors, window, window_properties)
+                    inhibit_idle, idle_inhibitors, window, window_properties,
+                    current_workspace)
 
 } // namespace swayipc::data

--- a/swayipc-cpp/src/data.cpp
+++ b/swayipc-cpp/src/data.cpp
@@ -31,7 +31,7 @@ DEFINE_ENUM(transform_t, {
 DEFINE_STRICT_TYPE(mode_s, width, height, refresh)
 
 DEFINE_TYPE_DEFAULT(output_s, name, make, model, serial, active, dpms, primary, scale, subpixel_hinting,
-                    transform, current_workspace, modes, current_mode, rect)
+                    transform, current_workspace, modes, current_mode, rect, focused)
 
 DEFINE_ENUM(bar_mode_t, {
         {bar_mode_t::DOCK, "dock"},


### PR DESCRIPTION
### Changes

Linking with CMake now works properly with:

```cmake
find_package(swayipc_cpp 1.0.0 REQUIRED)

target_link_libraries(
        ${CMAKE_PROJECT_NAME}
        PRIVATE
        swayipc_cpp::swayipc_cpp
)
```

Library name is renamed to `swayipc_cpp` and is still static by default. It can be configured to be shared with flag `-DBUILD_SHARED_LIBS=ON`.

Boolean field `focused` is added to `output_s`. 